### PR TITLE
Add V2 using new Azure.Messaging.ServiceBus library

### DIFF
--- a/src/Enable.Extensions.Messaging.Abstractions/BaseMessageProcessor.cs
+++ b/src/Enable.Extensions.Messaging.Abstractions/BaseMessageProcessor.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Enable.Extensions.Messaging.Abstractions
+{
+    public abstract class BaseMessageProcessor : IMessageProcessor
+    {
+        public abstract Task RegisterMessageHandler(
+            Func<IMessage, CancellationToken, Task> messageHandler,
+            Func<MessageHandlerExceptionContext, Task> errorHandler = null);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/src/Enable.Extensions.Messaging.Abstractions/IMessageProcessor.cs
+++ b/src/Enable.Extensions.Messaging.Abstractions/IMessageProcessor.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Enable.Extensions.Messaging.Abstractions
+{
+    public interface IMessageProcessor : IDisposable
+    {
+        /// <summary>
+        /// Register a message handler. This handler is awaited each time that
+        /// a new message is received.
+        /// </summary>
+        /// <param name="messageHandler">The handler that processes each message.</param>
+        /// <param name="errorHandler">The handler that processes errors.</param>
+        Task RegisterMessageHandler(
+            Func<IMessage, CancellationToken, Task> messageHandler,
+            Func<MessageHandlerExceptionContext, Task> errorHandler = null);
+    }
+}

--- a/src/Enable.Extensions.Messaging.Abstractions/IMessagingClientFactoryV2.cs
+++ b/src/Enable.Extensions.Messaging.Abstractions/IMessagingClientFactoryV2.cs
@@ -1,0 +1,12 @@
+namespace Enable.Extensions.Messaging.Abstractions
+{
+    public interface IMessagingClientFactoryV2
+    {
+        IMessagePublisher GetMessagePublisher(string topicName);
+
+        IMessageProcessor GetMessageProcessor(
+            string topicName,
+            string subscriptionName,
+            MessageHandlerOptions messageHandlerOptions);
+    }
+}

--- a/src/Enable.Extensions.Messaging.AzureServiceBus/AzureServiceBusMessagingClientFactoryV2.cs
+++ b/src/Enable.Extensions.Messaging.AzureServiceBus/AzureServiceBusMessagingClientFactoryV2.cs
@@ -1,0 +1,60 @@
+using System;
+using Enable.Extensions.Messaging.Abstractions;
+using Enable.Extensions.Messaging.AzureServiceBus.Internal.V2;
+
+namespace Enable.Extensions.Messaging.AzureServiceBus
+{
+    public class AzureServiceBusMessagingClientFactoryV2 : IMessagingClientFactoryV2
+    {
+        private readonly AzureServiceBusMessagingClientFactoryOptions _options;
+
+        public AzureServiceBusMessagingClientFactoryV2(AzureServiceBusMessagingClientFactoryOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (string.IsNullOrEmpty(options.ConnectionString))
+            {
+                throw new ArgumentNullException(nameof(options.ConnectionString));
+            }
+
+            _options = options;
+        }
+
+        public IMessagePublisher GetMessagePublisher(string topicName)
+        {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException(nameof(topicName));
+            }
+
+            return new AzureServiceBusMessagePublisherV2(
+                _options.ConnectionString,
+                topicName);
+        }
+
+        public IMessageProcessor GetMessageProcessor(
+            string topicName,
+            string subscriptionName,
+            MessageHandlerOptions messageHandlerOptions)
+        {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException(nameof(topicName));
+            }
+
+            if (string.IsNullOrWhiteSpace(subscriptionName))
+            {
+                throw new ArgumentException(nameof(subscriptionName));
+            }
+
+            return new AzureServiceBusMessageProcessor(
+                _options.ConnectionString,
+                topicName,
+                subscriptionName,
+                messageHandlerOptions);
+        }
+    }
+}

--- a/src/Enable.Extensions.Messaging.AzureServiceBus/Enable.Extensions.Messaging.AzureServiceBus.csproj
+++ b/src/Enable.Extensions.Messaging.AzureServiceBus/Enable.Extensions.Messaging.AzureServiceBus.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.10.0" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.0.2" />
   </ItemGroup>

--- a/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessageProcessor.cs
+++ b/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessageProcessor.cs
@@ -52,7 +52,7 @@ namespace Enable.Extensions.Messaging.AzureServiceBus.Internal.V2
             }
 
             _serviceBusProcessor.ProcessMessageAsync += (processMessageEventArgs) =>
-                messageHandler(new AzureServiceBusMessageV2(processMessageEventArgs.Message), default);
+                messageHandler(new AzureServiceBusMessageV2(processMessageEventArgs.Message), default(CancellationToken));
 
             _serviceBusProcessor.ProcessErrorAsync += (processErrorEventArgs) =>
                 errorHandler(new MessageHandlerExceptionContext(processErrorEventArgs.Exception));

--- a/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessageProcessor.cs
+++ b/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessageProcessor.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using Enable.Extensions.Messaging.Abstractions;
+
+namespace Enable.Extensions.Messaging.AzureServiceBus.Internal.V2
+{
+    public class AzureServiceBusMessageProcessor : BaseMessageProcessor
+    {
+        private readonly ServiceBusProcessor _serviceBusProcessor;
+
+        private bool _disposed;
+
+        public AzureServiceBusMessageProcessor(
+            string connectionString,
+            string topicName,
+            string subscriptionName,
+            MessageHandlerOptions messageHandlerOptions)
+        {
+            if (messageHandlerOptions is null)
+            {
+                throw new ArgumentNullException(nameof(messageHandlerOptions));
+            }
+
+            var options = new ServiceBusProcessorOptions
+            {
+                ReceiveMode = ServiceBusReceiveMode.PeekLock,
+                MaxConcurrentCalls = messageHandlerOptions.MaxConcurrentCalls,
+                AutoCompleteMessages = messageHandlerOptions.AutoComplete
+            };
+
+            _serviceBusProcessor = new ServiceBusClient(connectionString)
+                .CreateProcessor(
+                    topicName,
+                    subscriptionName,
+                    options);
+        }
+
+        public override Task RegisterMessageHandler(
+            Func<IMessage, CancellationToken, Task> messageHandler,
+            Func<MessageHandlerExceptionContext, Task> errorHandler = null)
+        {
+            if (messageHandler is null)
+            {
+                throw new ArgumentNullException(nameof(messageHandler));
+            }
+
+            if (errorHandler is null)
+            {
+                errorHandler = _ => Task.CompletedTask;
+            }
+
+            _serviceBusProcessor.ProcessMessageAsync += (processMessageEventArgs) =>
+                messageHandler(new AzureServiceBusMessageV2(processMessageEventArgs.Message), default);
+
+            _serviceBusProcessor.ProcessErrorAsync += (processErrorEventArgs) =>
+                errorHandler(new MessageHandlerExceptionContext(processErrorEventArgs.Exception));
+
+            return _serviceBusProcessor.StartProcessingAsync();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _serviceBusProcessor.CloseAsync()
+                        .GetAwaiter()
+                        .GetResult();
+                }
+
+                _disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessagePublisherV2.cs
+++ b/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessagePublisherV2.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using Enable.Extensions.Messaging.Abstractions;
+
+namespace Enable.Extensions.Messaging.AzureServiceBus.Internal.V2
+{
+    public class AzureServiceBusMessagePublisherV2 : BaseMessagePublisher
+    {
+        private readonly ServiceBusSender _serviceBusSender;
+
+        private bool _disposed;
+
+        public AzureServiceBusMessagePublisherV2(
+            string connectionString,
+            string topicName)
+        {
+            _serviceBusSender = new ServiceBusClient(connectionString).CreateSender(topicName);
+        }
+
+        public override Task EnqueueAsync(IMessage message, CancellationToken cancellationToken = default)
+        {
+            return _serviceBusSender.SendMessageAsync(MapMessageToAzureServiceBusMessage(message));
+        }
+
+        public override Task EnqueueAsync(IMessage message, DateTimeOffset scheduledTimeUtc, CancellationToken cancellationToken = default)
+        {
+            return _serviceBusSender.ScheduleMessageAsync(
+                MapMessageToAzureServiceBusMessage(message),
+                scheduledTimeUtc);
+        }
+
+        public override Task EnqueueBatchAsync(IEnumerable<IMessage> messages, CancellationToken cancellationToken = default)
+        {
+            var messageList = new List<ServiceBusMessage>();
+
+            foreach (var message in messages)
+            {
+                messageList.Add(MapMessageToAzureServiceBusMessage(message));
+            }
+
+            return _serviceBusSender.SendMessagesAsync(messageList);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _serviceBusSender.CloseAsync()
+                        .GetAwaiter()
+                        .GetResult();
+                }
+
+                _disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private ServiceBusMessage MapMessageToAzureServiceBusMessage(IMessage message)
+        {
+            var serviceBusMessage = new ServiceBusMessage(message.Body)
+            {
+                ContentType = "application/json"
+            };
+
+            if (!string.IsNullOrEmpty(message.MessageId))
+            {
+                serviceBusMessage.MessageId = message.MessageId;
+            }
+
+            return serviceBusMessage;
+        }
+    }
+}

--- a/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessagePublisherV2.cs
+++ b/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessagePublisherV2.cs
@@ -34,7 +34,8 @@ namespace Enable.Extensions.Messaging.AzureServiceBus.Internal.V2
         {
             return _serviceBusSender.ScheduleMessageAsync(
                 MapMessageToAzureServiceBusMessage(message),
-                scheduledTimeUtc);
+                scheduledTimeUtc,
+                cancellationToken);
         }
 
         public override Task EnqueueBatchAsync(
@@ -48,7 +49,7 @@ namespace Enable.Extensions.Messaging.AzureServiceBus.Internal.V2
                 messageList.Add(MapMessageToAzureServiceBusMessage(message));
             }
 
-            return _serviceBusSender.SendMessagesAsync(messageList);
+            return _serviceBusSender.SendMessagesAsync(messageList, cancellationToken);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessagePublisherV2.cs
+++ b/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessagePublisherV2.cs
@@ -20,19 +20,26 @@ namespace Enable.Extensions.Messaging.AzureServiceBus.Internal.V2
             _serviceBusSender = new ServiceBusClient(connectionString).CreateSender(topicName);
         }
 
-        public override Task EnqueueAsync(IMessage message, CancellationToken cancellationToken = default)
+        public override Task EnqueueAsync(
+            IMessage message,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             return _serviceBusSender.SendMessageAsync(MapMessageToAzureServiceBusMessage(message));
         }
 
-        public override Task EnqueueAsync(IMessage message, DateTimeOffset scheduledTimeUtc, CancellationToken cancellationToken = default)
+        public override Task EnqueueAsync(
+            IMessage message,
+            DateTimeOffset scheduledTimeUtc,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             return _serviceBusSender.ScheduleMessageAsync(
                 MapMessageToAzureServiceBusMessage(message),
                 scheduledTimeUtc);
         }
 
-        public override Task EnqueueBatchAsync(IEnumerable<IMessage> messages, CancellationToken cancellationToken = default)
+        public override Task EnqueueBatchAsync(
+            IEnumerable<IMessage> messages,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             var messageList = new List<ServiceBusMessage>();
 

--- a/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessageV2.cs
+++ b/src/Enable.Extensions.Messaging.AzureServiceBus/Internal/V2/AzureServiceBusMessageV2.cs
@@ -1,0 +1,23 @@
+using Azure.Messaging.ServiceBus;
+using Enable.Extensions.Messaging.Abstractions;
+
+namespace Enable.Extensions.Messaging.AzureServiceBus.Internal.V2
+{
+    public class AzureServiceBusMessageV2 : BaseMessage
+    {
+        private readonly ServiceBusReceivedMessage _message;
+
+        public AzureServiceBusMessageV2(ServiceBusReceivedMessage message)
+        {
+            _message = message;
+        }
+
+        public override string MessageId => _message.MessageId;
+
+        public override byte[] Body => _message.Body.ToArray();
+
+        public override uint DequeueCount => (uint)_message.DeliveryCount;
+
+        public override string LeaseId => _message.LockToken;
+    }
+}

--- a/src/Enable.Extensions.Messaging.RabbitMQ/Internal/RabbitMQMessageProcessor.cs
+++ b/src/Enable.Extensions.Messaging.RabbitMQ/Internal/RabbitMQMessageProcessor.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Enable.Extensions.Messaging.Abstractions;
+using RabbitMQ.Client;
+
+namespace Enable.Extensions.Messaging.RabbitMQ.Internal
+{
+    public class RabbitMQMessageProcessor : BaseMessageProcessor
+    {
+        private readonly RabbitMQMessageSubscriber _rabbitMQMessageSubscriber;
+        private readonly MessageHandlerOptions _messageHandlerOptions;
+
+        public RabbitMQMessageProcessor(
+            ConnectionFactory connectionFactory,
+            string topicName,
+            string subscriptionName,
+            MessageHandlerOptions messageHandlerOptions)
+        {
+            _rabbitMQMessageSubscriber = new RabbitMQMessageSubscriber(connectionFactory, topicName, subscriptionName);
+            _messageHandlerOptions = messageHandlerOptions ?? throw new ArgumentNullException(nameof(messageHandlerOptions));
+        }
+
+        public override Task RegisterMessageHandler(
+            Func<IMessage, CancellationToken, Task> messageHandler,
+            Func<MessageHandlerExceptionContext, Task> errorHandler = null)
+        {
+            if (messageHandler is null)
+            {
+                throw new ArgumentNullException(nameof(messageHandler));
+            }
+
+            _messageHandlerOptions.ExceptionReceivedHandler = errorHandler;
+
+            return _rabbitMQMessageSubscriber.RegisterMessageHandler(messageHandler, _messageHandlerOptions);
+        }
+    }
+}

--- a/src/Enable.Extensions.Messaging.RabbitMQ/Internal/RabbitMQMessageProcessor.cs
+++ b/src/Enable.Extensions.Messaging.RabbitMQ/Internal/RabbitMQMessageProcessor.cs
@@ -11,6 +11,8 @@ namespace Enable.Extensions.Messaging.RabbitMQ.Internal
         private readonly RabbitMQMessageSubscriber _rabbitMQMessageSubscriber;
         private readonly MessageHandlerOptions _messageHandlerOptions;
 
+        private bool _disposed;
+
         public RabbitMQMessageProcessor(
             ConnectionFactory connectionFactory,
             string topicName,
@@ -33,6 +35,21 @@ namespace Enable.Extensions.Messaging.RabbitMQ.Internal
             _messageHandlerOptions.ExceptionReceivedHandler = errorHandler;
 
             return _rabbitMQMessageSubscriber.RegisterMessageHandler(messageHandler, _messageHandlerOptions);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _rabbitMQMessageSubscriber.Dispose();
+                }
+
+                _disposed = true;
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Enable.Extensions.Messaging.RabbitMQ/Internal/RabbitMQMessageSubscriber.cs
+++ b/src/Enable.Extensions.Messaging.RabbitMQ/Internal/RabbitMQMessageSubscriber.cs
@@ -35,7 +35,7 @@ namespace Enable.Extensions.Messaging.RabbitMQ.Internal
             _exchangeName = GetExchangeName(topicName);
             _deadLetterExchangeName = GetDeadLetterExchangeName(topicName);
             _routingKey = string.Empty;
-            
+
             _queueName = GetQueueName(topicName, subscriptionName);
             _deadLetterQueueName = GetDeadLetterQueueName(topicName, subscriptionName);
 

--- a/src/Enable.Extensions.Messaging.RabbitMQ/RabbitMQMessagingClientFactoryV2.cs
+++ b/src/Enable.Extensions.Messaging.RabbitMQ/RabbitMQMessagingClientFactoryV2.cs
@@ -1,0 +1,59 @@
+using System;
+using Enable.Extensions.Messaging.Abstractions;
+using Enable.Extensions.Messaging.RabbitMQ.Internal;
+using RabbitMQ.Client;
+
+namespace Enable.Extensions.Messaging.RabbitMQ
+{
+    public class RabbitMQMessagingClientFactoryV2 : IMessagingClientFactoryV2
+    {
+        private readonly ConnectionFactory _connectionFactory;
+
+        public RabbitMQMessagingClientFactoryV2(RabbitMQMessagingClientFactoryOptions options)
+        {
+            _connectionFactory = new ConnectionFactory
+            {
+                HostName = options.HostName,
+                Port = options.Port,
+                VirtualHost = options.VirtualHost,
+                UserName = options.UserName,
+                Password = options.Password,
+                AutomaticRecoveryEnabled = true,
+                NetworkRecoveryInterval = TimeSpan.FromSeconds(10)
+            };
+        }
+
+        public IMessagePublisher GetMessagePublisher(string topicName)
+        {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException(nameof(topicName));
+            }
+
+            return new RabbitMQMessagePublisher(_connectionFactory, topicName);
+        }
+
+        public IMessageProcessor GetMessageProcessor(
+            string topicName,
+            string subscriptionName,
+            MessageHandlerOptions messageHandlerOptions)
+        {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException(nameof(topicName));
+            }
+
+            if (string.IsNullOrWhiteSpace(subscriptionName))
+            {
+                throw new ArgumentException(nameof(subscriptionName));
+            }
+
+            if (messageHandlerOptions is null)
+            {
+                throw new ArgumentNullException(nameof(messageHandlerOptions));
+            }
+
+            return new RabbitMQMessageProcessor(_connectionFactory, topicName, subscriptionName, messageHandlerOptions);
+        }
+    }
+}

--- a/test/Enable.Extensions.Messaging.AzureServiceBus.Tests/AzureServiceBusMessageProcessorTests.cs
+++ b/test/Enable.Extensions.Messaging.AzureServiceBus.Tests/AzureServiceBusMessageProcessorTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Enable.Extensions.Messaging.Abstractions;
+using Xunit;
+
+namespace Enable.Extensions.Messaging.AzureServiceBus.Tests
+{
+    public class AzureServiceBusMessageProcessorTests : IClassFixture<AzureServiceBusTestFixture>, IDisposable
+    {
+        private readonly AzureServiceBusTestFixture _fixture;
+
+        private readonly IMessagePublisher _messagePublisher;
+
+        private readonly IMessageProcessor _sut;
+
+        private bool _disposed;
+
+        public AzureServiceBusMessageProcessorTests(AzureServiceBusTestFixture fixture)
+        {
+            var options = new AzureServiceBusMessagingClientFactoryOptions
+            {
+                ConnectionString = fixture.ConnectionString
+            };
+
+            var messagingClientFactory = new AzureServiceBusMessagingClientFactoryV2(options);
+
+            var messageHandlerOptions = new MessageHandlerOptions
+            {
+                MaxConcurrentCalls = 1,
+                ExceptionReceivedHandler = (_) => Task.CompletedTask
+            };
+
+            _messagePublisher = messagingClientFactory.GetMessagePublisher(
+                fixture.TopicName);
+
+            _sut = messagingClientFactory.GetMessageProcessor(
+                fixture.TopicName,
+                fixture.SubscriptionName,
+                messageHandlerOptions);
+
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task RegisterMessageHandler_CanInvoke()
+        {
+            // Act
+            await _sut.RegisterMessageHandler(
+                (message, cancellationToken) => throw new Exception("There should be no messages to process."));
+        }
+
+        [Fact]
+        public async Task RegisterMessageHandler_MessageHandlerInvoked()
+        {
+            // Arrange
+            var evt = new ManualResetEvent(false);
+
+            Task MessageHandler(IMessage message, CancellationToken cancellationToken)
+            {
+                evt.Set();
+                return Task.CompletedTask;
+            }
+
+            await _sut.RegisterMessageHandler(MessageHandler);
+
+            // Act
+            await _messagePublisher.EnqueueAsync(
+                Guid.NewGuid().ToString(),
+                CancellationToken.None);
+
+            // Assert
+            Assert.True(evt.WaitOne(TimeSpan.FromSeconds(1)));
+        }
+
+        [Fact]
+        public async Task RegisterMessageHandler_ThrowsOnMutipleMessageHandlerRegistrations()
+        {
+            // Arrange
+            Task MessageHandler(IMessage message, CancellationToken cancellationToken)
+            {
+                throw new Exception("There should be no messages to process.");
+            }
+
+            await _sut.RegisterMessageHandler(MessageHandler);
+
+            // Act
+            var exception = await Record.ExceptionAsync(() => _sut.RegisterMessageHandler(MessageHandler));
+
+            // Assert
+            Assert.IsType<NotSupportedException>(exception);
+        }
+
+        [Fact]
+        public async Task RegisterMessageHandler_ExceptionHandlerInvoked()
+        {
+            // Arrange
+            var evt = new ManualResetEvent(false);
+
+            Task MessageHandler(IMessage message, CancellationToken cancellationToken)
+            {
+                throw new Exception("Message failed processing.");
+            }
+
+            Task ExceptionHandler(MessageHandlerExceptionContext context)
+            {
+                evt.Set();
+                return Task.CompletedTask;
+            }
+
+            await _sut.RegisterMessageHandler(MessageHandler, ExceptionHandler);
+
+            // Act
+            await _messagePublisher.EnqueueAsync(
+                Guid.NewGuid().ToString(),
+                CancellationToken.None);
+
+            // Assert
+            Assert.True(evt.WaitOne(TimeSpan.FromSeconds(1)));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _sut.Dispose();
+
+                    try
+                    {
+                        // Make a best effort to clear our test queue.
+                        _fixture.ClearQueue()
+                            .GetAwaiter()
+                            .GetResult();
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/test/Enable.Extensions.Messaging.AzureServiceBus.Tests/AzureServiceBusMessagePublisherV2Tests.cs
+++ b/test/Enable.Extensions.Messaging.AzureServiceBus.Tests/AzureServiceBusMessagePublisherV2Tests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Enable.Extensions.Messaging.Abstractions;
+using Xunit;
+
+namespace Enable.Extensions.Messaging.AzureServiceBus.Tests
+{
+    public class AzureServiceBusMessagePublisherV2Tests : IClassFixture<AzureServiceBusTestFixture>, IDisposable
+    {
+        private readonly AzureServiceBusTestFixture _fixture;
+
+        private readonly IMessagePublisher _sut;
+
+        private bool _disposed;
+
+        public AzureServiceBusMessagePublisherV2Tests(AzureServiceBusTestFixture fixture)
+        {
+            var options = new AzureServiceBusMessagingClientFactoryOptions
+            {
+                ConnectionString = fixture.ConnectionString
+            };
+
+            var messagingClientFactory = new AzureServiceBusMessagingClientFactoryV2(options);
+
+            _sut = messagingClientFactory.GetMessagePublisher(
+                fixture.TopicName);
+
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithString()
+        {
+            // Arrange
+            var content = Guid.NewGuid().ToString();
+
+            // Act
+            await _sut.EnqueueAsync(content, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueBatchAsync_CanInvokeWithStringCollection()
+        {
+            // Arrange
+            var batch = new string[]
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            // Act
+            await _sut.EnqueueBatchAsync(batch, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithByteArray()
+        {
+            // Arrange
+            var content = Encoding.UTF8.GetBytes(Guid.NewGuid().ToString());
+
+            // Act
+            await _sut.EnqueueAsync(content, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithCustomMessageType()
+        {
+            // Arrange
+            var content = new CustomMessageType
+            {
+                Message = Guid.NewGuid().ToString()
+            };
+
+            // Act
+            await _sut.EnqueueAsync(content, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueBatchAsync_CanInvokeWithCustomMessageTypeCollection()
+        {
+            // Arrange
+            var batch = new CustomMessageType[]
+            {
+                new CustomMessageType { Message = Guid.NewGuid().ToString() },
+                new CustomMessageType { Message = Guid.NewGuid().ToString() }
+            };
+
+            // Act
+            await _sut.EnqueueBatchAsync(batch, CancellationToken.None);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _sut.Dispose();
+
+                    try
+                    {
+                        // Make a best effort to clear our test queue.
+                        _fixture.ClearQueue()
+                            .GetAwaiter()
+                            .GetResult();
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                _disposed = true;
+            }
+        }
+
+        private class CustomMessageType
+        {
+            public string Message { get; set; }
+        }
+    }
+}

--- a/test/Enable.Extensions.Messaging.RabbitMQ.Tests/RabbitMQMessageProcessorTests.cs
+++ b/test/Enable.Extensions.Messaging.RabbitMQ.Tests/RabbitMQMessageProcessorTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Enable.Extensions.Messaging.Abstractions;
+using Xunit;
+
+namespace Enable.Extensions.Messaging.RabbitMQ.Tests
+{
+    public class RabbitMQMessageProcessorTests : IClassFixture<RabbitMQTestFixture>, IDisposable
+    {
+        private readonly RabbitMQTestFixture _fixture;
+
+        private readonly IMessagePublisher _messagePublisher;
+
+        private readonly IMessageProcessor _sut;
+
+        private bool _disposed;
+
+        public RabbitMQMessageProcessorTests(RabbitMQTestFixture fixture)
+        {
+            var options = new RabbitMQMessagingClientFactoryOptions
+            {
+                HostName = fixture.HostName,
+                Port = fixture.Port,
+                VirtualHost = fixture.VirtualHost,
+                UserName = fixture.UserName,
+                Password = fixture.Password
+            };
+
+            var messagingClientFactory = new RabbitMQMessagingClientFactoryV2(options);
+
+            var messageHandlerOptions = new MessageHandlerOptions
+            {
+                MaxConcurrentCalls = 1,
+                ExceptionReceivedHandler = (_) => Task.CompletedTask
+            };
+
+            _messagePublisher = messagingClientFactory.GetMessagePublisher(
+                fixture.TopicName);
+
+            _sut = messagingClientFactory.GetMessageProcessor(
+                fixture.TopicName,
+                fixture.SubscriptionName,
+                messageHandlerOptions);
+
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task RegisterMessageHandler_CanInvoke()
+        {
+            // Act
+            await _sut.RegisterMessageHandler(
+                (message, cancellationToken) => throw new Exception("There should be no messages to process."));
+        }
+
+        [Fact]
+        public async Task RegisterMessageHandler_ThrowsOnMutipleMessageHandlerRegistrations()
+        {
+            // Arrange
+            Task MessageHandler(IMessage message, CancellationToken cancellationToken)
+            {
+                throw new Exception("There should be no messages to process.");
+            }
+
+            await _sut.RegisterMessageHandler(MessageHandler);
+
+            // Act
+            var exception = await Record.ExceptionAsync(() => _sut.RegisterMessageHandler(MessageHandler));
+
+            // Assert
+            Assert.IsType<InvalidOperationException>(exception);
+        }
+
+        [Fact]
+        public async Task RegisterMessageHandler_MessageHandlerInvoked()
+        {
+            // Arrange
+            var evt = new ManualResetEvent(false);
+
+            Task MessageHandler(IMessage message, CancellationToken cancellationToken)
+            {
+                evt.Set();
+                return Task.CompletedTask;
+            }
+
+            await _sut.RegisterMessageHandler(MessageHandler);
+
+            evt.WaitOne(TimeSpan.FromSeconds(1));
+
+            // Act
+            await _messagePublisher.EnqueueAsync(
+                Guid.NewGuid().ToString(),
+                CancellationToken.None);
+
+            // Assert
+            Assert.True(evt.WaitOne(TimeSpan.FromSeconds(1)));
+        }
+
+        [Fact]
+        public async Task RegisterMessageHandler_ExceptionHandlerInvoked()
+        {
+            // Arrange
+            var evt = new ManualResetEvent(false);
+
+            Task MessageHandler(IMessage message, CancellationToken cancellationToken)
+            {
+                throw new Exception("Message failed processing.");
+            }
+
+            Task ExceptionHandler(MessageHandlerExceptionContext context)
+            {
+                evt.Set();
+                return Task.CompletedTask;
+            }
+
+            await _sut.RegisterMessageHandler(MessageHandler, ExceptionHandler);
+
+            // Act
+            await _messagePublisher.EnqueueAsync(
+                Guid.NewGuid().ToString(),
+                CancellationToken.None);
+
+            // Assert
+            Assert.True(evt.WaitOne(TimeSpan.FromSeconds(1)));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    // With the RabbitMQ implementation, we must disconnect
+                    // our consumer before purging the queue, otherwise,
+                    // purging the queue won't remove unacked messages.
+                    _sut.Dispose();
+
+                    try
+                    {
+                        // Make a best effort to clear our test queue.
+                        _fixture.ClearQueue();
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/test/Enable.Extensions.Messaging.RabbitMQ.Tests/RabbitMQMessageProcessorTests.cs
+++ b/test/Enable.Extensions.Messaging.RabbitMQ.Tests/RabbitMQMessageProcessorTests.cs
@@ -86,8 +86,6 @@ namespace Enable.Extensions.Messaging.RabbitMQ.Tests
 
             await _sut.RegisterMessageHandler(MessageHandler);
 
-            evt.WaitOne(TimeSpan.FromSeconds(1));
-
             // Act
             await _messagePublisher.EnqueueAsync(
                 Guid.NewGuid().ToString(),


### PR DESCRIPTION
Add V2 using new `Azure.Messaging.ServiceBus` library instead of deprecated `Microsoft.Azure.ServiceBus`.

Only `MessageProcessors` are supported in V2.