### PR TITLE
Downgrade to net standard 2.0

### DIFF
--- a/src/Enable.Extensions.Messaging.Abstractions/Enable.Extensions.Messaging.Abstractions.csproj
+++ b/src/Enable.Extensions.Messaging.Abstractions/Enable.Extensions.Messaging.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Enable.Extensions.Messaging.AzureServiceBus/Enable.Extensions.Messaging.AzureServiceBus.csproj
+++ b/src/Enable.Extensions.Messaging.AzureServiceBus/Enable.Extensions.Messaging.AzureServiceBus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Enable.Extensions.Messaging.RabbitMQ/Enable.Extensions.Messaging.RabbitMQ.csproj
+++ b/src/Enable.Extensions.Messaging.RabbitMQ/Enable.Extensions.Messaging.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 


### PR DESCRIPTION
Downgrade to net standard 2.0. The initial upgrade to 2.1 seems unnecessary, and downgrading improves compatability.