### PR TITLE
Implement SessionId as null by default for consumers not using sessions

### DIFF
--- a/src/Enable.Extensions.Messaging.Abstractions/BaseMessage.cs
+++ b/src/Enable.Extensions.Messaging.Abstractions/BaseMessage.cs
@@ -7,7 +7,7 @@ namespace Enable.Extensions.Messaging.Abstractions
     {
         public abstract string MessageId { get; }
 
-        public string SessionId => null;
+        public virtual string SessionId => null;
 
         public abstract string LeaseId { get; }
 

--- a/src/Enable.Extensions.Messaging.Abstractions/BaseMessage.cs
+++ b/src/Enable.Extensions.Messaging.Abstractions/BaseMessage.cs
@@ -7,7 +7,7 @@ namespace Enable.Extensions.Messaging.Abstractions
     {
         public abstract string MessageId { get; }
 
-        public abstract string SessionId { get; }
+        public string SessionId => null;
 
         public abstract string LeaseId { get; }
 


### PR DESCRIPTION
Avoids `NotImplementedException`s amongst consumers of this package by default where consumers of the event don't use sessions.